### PR TITLE
Add a `from_json` filter to the jinja environment

### DIFF
--- a/bmgr/server.py
+++ b/bmgr/server.py
@@ -221,8 +221,10 @@ def get_alias(alias_name, hostname=None, allow_fail=False):
 
 def render(tpl, context):
   path = parse_template_uri(tpl)
-  return jinja2.Environment(loader = jinja2.FileSystemLoader(
-      current_app.config['BMGR_TEMPLATE_PATH'])).get_template(path).render(
+  environment = jinja2.Environment(loader = jinja2.FileSystemLoader(
+      current_app.config['BMGR_TEMPLATE_PATH']))
+  environment.filters["from_json"] = json.loads
+  return environment.get_template(path).render(
     context)
 
 def delete_profile(name):


### PR DESCRIPTION
This filter is backed to `json.loads` it will allow to provide similar/compatible templating than the [`from_json`](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#formatting-data-yaml-and-json) filter in ansible

Closes #1 