### PR TITLE
Feature/data handling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ From the repository root:
 # docker exec -ti bmgr_bmgr_1 /bin/bash
 ```
 
-3. Initialize the datbase
+3. Initialize the database
 ```bash
 # FLASK_APP=bmgr.app flask initdb
 ```

--- a/README.md
+++ b/README.md
@@ -153,3 +153,19 @@ $ bmgr resource list
 - [Add alias override](docs/aliases.md#add-alias-override): `POST /api/v1.0/aliases/:alias`
 - [Delete global alias](docs/aliases.md#delete-alias): `DELETE /api/v1.0/aliases/:alias`
 - [Delete host-alias](docs/aliases.md#delete-alias-override): `DELETE /api/v1.0/aliases/:alias/:hostname`
+
+## Database initialization
+
+Database initialisation can be customized through the following configuration key with the default value:
+
+```
+BMGR_INIT_DATA = [
+    {"type": "resource", "name": "ipxe_normal_boot", "template_uri": "file://disk_boot.ipxe.jinja"},
+    {"type": "resource", "name": "ipxe_deploy_boot", "template_uri": "file://deploy_boot.ipxe.jinja"},
+    {"type": "resource", "name": "kickstart", "template_uri": "file://ks_rhel7.jinja"},
+    {"type": "resource", "name": "poap_config", "template_uri": "file://poap_config.jinja"},
+    {"type": "alias", "name": "ipxe_boot", "target": "ipxe_normal_boot"}
+]
+```
+
+Both resources and aliases can be set in an idempotent way: So, the **initdb** Flask script can safely be re-applied during upgrades or restarts, as existing resources and aliases are not recreated.

--- a/bmgr/__init__.py
+++ b/bmgr/__init__.py
@@ -7,7 +7,7 @@ def create_app(test_config=None):
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
 
-    # Outside of tests, conf is passed via a file, by default /etc/bmgr.conf
+    # Outside of tests, conf is passed via a file, by default /etc/bmgr/bmgr.conf
     # or the location specified in BMGR_CONF_FILE
     if test_config is None:
         app.config.from_envvar('BMGR_CONF_FILE', silent=True) or \
@@ -19,7 +19,7 @@ def create_app(test_config=None):
     db_uri = (os.environ.get('BMGR_DB_URI', None) or
               app.config.get('BMGR_DB_URI', None))
 
-    # BUILD the database URI unless explicitely specified
+    # BUILD the database URI unless explicitly specified
     if db_uri:
         app.config['SQLALCHEMY_DATABASE_URI'] = db_uri
     else:

--- a/bmgr/__init__.py
+++ b/bmgr/__init__.py
@@ -1,11 +1,20 @@
-import os
+import os, logging
 
 from flask import Flask
 from . import server
 
+def get_int_param(app, name, default):
+    val = os.environ.get(name)
+    if val is not None:
+        return int(val)
+    return int(app.config.get(name, default))
+
 def create_app(test_config=None):
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
+
+    # Logger
+    logger = logging.getLogger(__name__)
 
     # Outside of tests, conf is passed via a file, by default /etc/bmgr/bmgr.conf
     # or the location specified in BMGR_CONF_FILE
@@ -33,8 +42,12 @@ def create_app(test_config=None):
             raise ValueError("Please provide a database host and user/password "
                              "or URI")
 
+    # DB Pool connection config
+    pool_size = get_int_param(app,'BMGR_DB_POOL_SIZE', 20)
+    pool_recycle = get_int_param(app,'BMGR_DB_POOL_RECYCLE', 600)
+
     app.config.setdefault('BMGR_TEMPLATE_PATH', '/etc/bmgr/templates/')
-    app.config.setdefault('SQLALCHEMY_ENGINE_OPTIONS', {'pool_recycle' : 600})
+    app.config.setdefault('SQLALCHEMY_ENGINE_OPTIONS', {'pool_size': pool_size, 'pool_recycle': pool_recycle})
     app.config.setdefault('SQLALCHEMY_TRACK_MODIFICATIONS', False)
     app.register_blueprint(server.bp)
 
@@ -47,8 +60,14 @@ def create_app(test_config=None):
     # Initialize the SQLAlchemy db object
     server.db.init_app(app)
 
+    # Initialize the db and data if present in conf
+    init_data = app.config.get('BMGR_INIT_DATA', [])
+
+    # Log config
+    logger.info(app.config)
+
     @app.cli.command(help='Intialize the bmgr database')
     def initdb():
-        server.init_db()
+        server.init_db(init_data)
 
     return app

--- a/bmgr/server.py
+++ b/bmgr/server.py
@@ -1,5 +1,5 @@
 from flask import (
-  Flask, Blueprint, jsonify, make_response, abort, request, g, current_app
+  Blueprint, jsonify, make_response, abort, g, current_app
 )
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm import joinedload, relationship, synonym, validates
@@ -7,10 +7,9 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import UniqueConstraint, and_
 from flask_expects_json import expects_json
-from ClusterShell import NodeSet
 from ClusterShell.NodeSet import NodeSet as nodeset
 
-import subprocess, tempfile, os, stat, flask, json, jinja2, sys, itertools, time
+import json, jinja2, sys, itertools
 import re
 
 MAX_NODESET = 100000
@@ -48,7 +47,7 @@ class Profile(db.Model):
       self.weight = weight
 
   def __repr__(self):
-      return '<Profile %r>' % (self.name)
+      return '<Profile %r>' % self.name
 
   def to_dict(self):
     return {'name': self.name,
@@ -88,7 +87,7 @@ class Host(db.Model):
     self.hostname = hostname
 
   def __repr__(self):
-    return '<Host %r>' % (self.hostname)
+    return '<Host %r>' % self.hostname
 
   @property
   def attributes(self):
@@ -129,7 +128,7 @@ class Resource(db.Model):
     self.template_uri = template_uri
 
   def __repr__(self):
-      return '<Resource %r>' % (self.name)
+      return '<Resource %r>' % self.name
 
   def to_dict(self):
     return {'name': self.name,
@@ -158,7 +157,7 @@ class Alias(db.Model):
     self.autodelete = autodelete
 
   def __repr__(self):
-    return '<Alias %r>' % (self.name)
+    return '<Alias %r>' % self.name
 
 @bp.errorhandler(404)
 def not_found(error):
@@ -230,7 +229,7 @@ def delete_profile(name):
   db.session.delete(p)
 
 def query_hosts(host_list=None, check_count=False):
-  hosts = db.session.query(Host).options(joinedload('profiles'))
+  hosts = db.session.query(Host).options(joinedload(Host.profiles))
 
   if host_list is not None:
       hosts = hosts.filter(Host.hostname.in_(host_list))
@@ -266,7 +265,7 @@ def get_hosts_folded(host_list=None):
         'profiles': [p.name for p in sorted(profiles)],
         'attributes': merge_profile_attributes(profiles)})
 
-  return sorted(folded_list, key = lambda g: g['profiles'])
+  return sorted(folded_list, key = lambda x: x['profiles'])
 
 def delete_hosts(host_list):
   db_hosts = query_hosts(host_list, check_count=True)
@@ -291,8 +290,7 @@ def get_host(hostname):
   'required': ['name']
 })
 def api_hosts_post():
-  db_hosts = []
-  t0 = time.time()
+  host_list = []
   try:
     host_list = nodeset(g.data['name'])
     if len(host_list) > MAX_NODESET:
@@ -307,9 +305,8 @@ def api_hosts_post():
         db.session.flush()
 
     db.session.commit()
-  except SQLAlchemyError:
-    # FIXME: Discriminate errors
-    json_abort(409, "Host already exists")
+  except SQLAlchemyError as e:
+    json_abort(409, str(e.__dict__['orig']))
 
   folded_hosts = get_hosts_folded(host_list)
   return jsonify(folded_hosts)
@@ -366,13 +363,13 @@ def api_hosts_hostname_get(hostname):
   'required': ['name']
 })
 def api_profiles_post():
+  profile = None
   try:
     profile = Profile.from_dict(g.data)
     db.session.add(profile)
     db.session.commit()
-  #FIXME: discriminate errors
-  except SQLAlchemyError:
-    json_abort(409, "Profile already exists")
+  except SQLAlchemyError as e:
+    json_abort(409, str(e.__dict__['orig']))
 
   return jsonify(profile.to_dict())
 
@@ -442,13 +439,13 @@ def api_resources_get():
   'required': ['name', 'template_uri']
 })
 def api_resources_post():
+  resource = None
   try:
     resource = Resource.from_dict(g.data)
     db.session.add(resource)
     db.session.commit()
-  #FIXME: discriminate errors
-  except SQLAlchemyError:
-    json_abort(409, "Resource already exists")
+  except SQLAlchemyError as e:
+    json_abort(409, str(e.__dict__['orig']))
 
   return jsonify(resource.to_dict())
 
@@ -519,7 +516,6 @@ def api_resources_resource_render(name, hostname):
   'required': ['name', 'target']
 })
 def api_aliases_post():
-  exists = query_aliases(g.data['name'])
   if query_aliases(g.data['name']).count() > 0:
     json_abort(409, "Alias already exists")
 
@@ -543,10 +539,10 @@ def api_aliases_post():
   'required': ['hosts', 'target']
 })
 def api_aliases_alias_post(name):
-  exists = query_aliases(name)
+  query_aliases(name)
 
   # Check if the main alias is defined
-  main_alias = get_alias(name)
+  get_alias(name)
 
   if query_aliases(name, nodeset(g.data['hosts'])).count() > 0:
     json_abort(409, "Alias or override already exists")

--- a/bmgr/server.py
+++ b/bmgr/server.py
@@ -171,23 +171,30 @@ def unauthorized(error):
 def conflict(error):
   return make_response(jsonify({'error': 'Conflict'}), 409)
 
-def init_db():
+def init_db(data):
   db.create_all()
 
-  normal_boot = Resource('ipxe_normal_boot', 'file://disk_boot.ipxe.jinja')
-  deploy_boot = Resource('ipxe_deploy_boot', 'file://deploy_boot.ipxe.jinja')
-  boot_alias = Alias('ipxe_boot', normal_boot, None)
-  kickstart = Resource('kickstart', 'file://ks_rhel7.jinja')
-  poap = Resource('poap_config', 'file://poap_config.jinja')
-  db.session.add(normal_boot)
-  db.session.add(deploy_boot)
-  db.session.add(boot_alias)
-  db.session.add(kickstart)
-  db.session.add(poap)
+  if not data:
+    return
+
+  resources = [e for e in data if e.get("type") == "resource"]
+  aliases = [e for e in data if e.get("type") == "alias"]
+
+  # Create firstly resources as aliases depend on them if not exist
+  for res in resources:
+    if get_resource(res.get('name'), True) is None:
+      db.session.add(Resource(res.get('name'), res.get('template_uri')))
+
+  # Create next aliases if not exist
+  for alias in aliases:
+    r = get_resource(alias.get('target'))
+    if get_alias(alias.get('name'), None, True) is None:
+      db.session.add(Alias(alias.get('name'), r, None))
+
   db.session.commit()
 
-
 def get_profile(profile_name):
+  p = None
   try:
     p = db.session.query(Profile).filter_by(name=profile_name).one()
   except NoResultFound:
@@ -195,11 +202,15 @@ def get_profile(profile_name):
 
   return p
 
-def get_resource(resource_name):
+def get_resource(resource_name, allow_fail=False):
+  r = None
   try:
     r = db.session.query(Resource).filter_by(name=resource_name).one()
   except NoResultFound:
-    json_abort(404, "Resource '{}' not found".format(resource_name))
+    if allow_fail:
+      return None
+    else:
+      json_abort(404, "Resource '{}' not found".format(resource_name))
 
   return r
 
@@ -628,4 +639,5 @@ def api_aliases_alias_get(name):
 
 if __name__ == "__main__":
   if sys.argv[1] == 'initdb':
-    init_db()
+    init_data = current_app.config.get("BMGR_INIT_DATA", [])
+    init_db(init_data)

--- a/bmgr/server.py
+++ b/bmgr/server.py
@@ -29,7 +29,7 @@ class Profile(db.Model):
   id = db.Column(db.Integer, primary_key=True)
   name = db.Column(db.String(255), unique=True)
   weight = db.Column(db.Integer, default=0)
-  _attributes = db.Column('attributes', db.String(8000))
+  _attributes = db.Column('attributes', db.String())
 
   @property
   def attributes(self):

--- a/confs/bmgr.conf
+++ b/confs/bmgr.conf
@@ -6,3 +6,12 @@ BMGR_TEMPLATE_PATH="/etc/bmgr/templates/"
 
 #Client configuration
 BMGR_CLIENT_URL="http://localhost/bmgr"
+
+# init data
+BMGR_INIT_DATA = [
+    {"type": "resource", "name": "ipxe_normal_boot", "template_uri": "file://disk_boot.ipxe.jinja"},
+    {"type": "resource", "name": "ipxe_deploy_boot", "template_uri": "file://deploy_boot.ipxe.jinja"},
+    {"type": "resource", "name": "kickstart", "template_uri": "file://ks_rhel7.jinja"},
+    {"type": "resource", "name": "poap_config", "template_uri": "file://poap_config.jinja"},
+    {"type": "alias", "name": "ipxe_boot", "target": "ipxe_normal_boot"}
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,27 @@
+import pytest
+from flask import Flask
+
+from bmgr import get_int_param
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["TEST_INT_PARAM"] = 42
+    app.config["TEST_BOOL_PARAM"] = True
+    return app
+
+def test_get_int_param_with_env_var(app, monkeypatch):
+    monkeypatch.setenv("TEST_INT_PARAM", "10")
+
+    assert get_int_param(app, "TEST_INT_PARAM", 99) == 10
+
+def test_get_int_param_with_app_config(app, monkeypatch):
+    monkeypatch.delenv("TEST_INT_PARAM", raising=False)
+
+    assert get_int_param(app, "TEST_INT_PARAM", 99) == 42
+
+def test_get_int_param_with_default(app, monkeypatch):
+    monkeypatch.delenv("TEST_INT_PARAM", raising=False)
+    app.config.pop("TEST_INT_PARAM", None)
+
+    assert get_int_param(app, "TEST_INT_PARAM", 99) == 99

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,7 +15,14 @@ def client():
     client_config = {
        'BMGR_DB_URI': 'sqlite:///{0}'.format(db_path),
        'TESTING': True,
-       'BMGR_TEMPLATE_PATH': template_path
+       'BMGR_TEMPLATE_PATH': template_path,
+       'BMGR_INIT_DATA': [
+         {"type": "resource", "name": "ipxe_normal_boot", "template_uri": "file://disk_boot.ipxe.jinja"},
+         {"type": "resource", "name": "ipxe_deploy_boot", "template_uri": "file://deploy_boot.ipxe.jinja"},
+         {"type": "resource", "name": "kickstart", "template_uri": "file://ks_rhel7.jinja"},
+         {"type": "resource", "name": "poap_config", "template_uri": "file://poap_config.jinja"},
+         {"type": "alias", "name": "ipxe_boot", "target": "ipxe_normal_boot"}
+        ]
        #'SQLALCHEMY_ECHO': True
        }
 
@@ -23,8 +30,10 @@ def client():
     client = app.test_client()
 
     app.testing = True
-    with app.app_context():
-        bmgr.server.init_db()
+    # init_db must be idempotent
+    for n in range(2):
+        with app.app_context():
+            bmgr.server.init_db(app.config.get("BMGR_INIT_DATA", []))
 
     with open(os.path.join(template_path, 'boot.jinja'), 'w+') as f:
         f.write('boot: a: {{ a }} b: {{ b }}')
@@ -86,7 +95,7 @@ def test_hosts(client):
     assert r.get_json() == [{ 'name': 'node59', 'profiles': [], 'attributes': {} }]
 
 
-    # Delete non existing host
+    # Delete non-existing host
     r = client.delete('/api/v1.0/hosts/aaa')
     assert r.status_code == 404
     assert r.get_json() == {'error': 'Host not found'}
@@ -193,7 +202,7 @@ def test_host_profiles(client):
 
         assert r.status_code == 200
 
-    # Create hosts with non existing profiles
+    # Create hosts with non-existing profiles
     r = client.post('/api/v1.0/hosts',
                     json = { 'name': 'node[0-9]' ,
                              'profiles': ['profileA', 'profileC']}
@@ -216,7 +225,7 @@ def test_host_profiles(client):
         'profiles': ['profileA'],
         'attributes': {'a': '1'}}]
 
-    # Update profiles for non existing host
+    # Update profiles for non-existing host
     r = client.patch('/api/v1.0/hosts/node20',
                     json = {'profiles': ['profileA', 'profileB']})
     assert r.status_code == 404

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -73,6 +73,7 @@ def test_hosts(client):
                         json = { 'name': hosts }
                         )
         assert r.status_code == 409
+        assert r.get_json() == {'error': 'UNIQUE constraint failed: hosts.hostname'}
 
     # List hosts
     r = client.get('/api/v1.0/hosts')
@@ -135,6 +136,7 @@ def test_profiles(client):
                         json = p)
 
         assert r.status_code == 409
+        assert r.get_json() == {'error': 'UNIQUE constraint failed: profiles.name'}
 
     # List profiles attributes
     for p in profiles:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -345,10 +345,12 @@ def test_resources(client):
     r = client.post('/api/v1.0/resources',
                     json = {'name': 'boot',
                     'template_uri': 'file://boot.jinja'})
+    assert r.status_code == 200
 
     r = client.post('/api/v1.0/resources',
                     json = {'name': 'deploy',
                     'template_uri': 'file://deploy.jinja'})
+    assert r.status_code == 200
 
     r = client.get('/api/v1.0/resources/boot/node0')
     assert r.status_code == 200
@@ -398,6 +400,7 @@ def test_resources(client):
     r = client.patch('/api/v1.0/resources/boot',
                     json = {'name': 'boot',
                     'template_uri': 'file://bad.jinja'})
+    assert r.status_code == 200
 
     r = client.get('/api/v1.0/resources/boot/node0')
     assert r.status_code == 400
@@ -434,10 +437,12 @@ def test_aliases(client):
     r = client.post('/api/v1.0/resources',
                     json = {'name': 'boot',
                     'template_uri': 'file://boot.jinja'})
+    assert r.status_code == 200
 
     r = client.post('/api/v1.0/resources',
                     json = {'name': 'deploy',
                     'template_uri': 'file://deploy.jinja'})
+    assert r.status_code == 200
 
     r = client.post('/api/v1.0/aliases',
                     json={'name': 'myalias',


### PR DESCRIPTION
Hi @fihuer, this PR brings some improvements around data handling:

-  Fix SQLAlchemy 2.0 issue for strings not more accepted for attribute names
>“Using strings to represent relationship names in ORM operations such as Query.join(), as well as strings for all ORM >attribute names in loader options like selectinload() is deprecated and will be removed in SQLAlchemy 2.0. The class->bound attribute should be passed instead.”
>https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#orm-query-joining-loading-on-relationships-uses-attributes-not-strings
```python
  hosts = db.session.query(Host).options(joinedload(Host.profiles))
```
- Return SQLAlchemy error messages for conflicts instead of "already exists" static message

- Allow configuring SQLAlchemy db connection pool (pool size and recycle)
```python
# DB Pool connection config
    pool_size = get_int_param(app,'BMGR_DB_POOL_SIZE', 20)
    pool_recycle = get_int_param(app,'BMGR_DB_POOL_RECYCLE', 600)

    app.config.setdefault('SQLALCHEMY_ENGINE_OPTIONS', {'pool_size': pool_size, 'pool_recycle': pool_recycle})
```

- Allow customizing data initialization in an idempotent way for alias and resources from config instead of specific code
```python
# init data
BMGR_INIT_DATA = [
    {"type": "resource", "name": "ipxe_normal_boot", "template_uri": "file://disk_boot.ipxe.jinja"},
    {"type": "resource", "name": "ipxe_deploy_boot", "template_uri": "file://deploy_boot.ipxe.jinja"},
    {"type": "resource", "name": "kickstart", "template_uri": "file://ks_rhel7.jinja"},
    {"type": "resource", "name": "poap_config", "template_uri": "file://poap_config.jinja"},
    {"type": "alias", "name": "ipxe_boot", "target": "ipxe_normal_boot"}
]
```


- Unlimit text length for profile data storage as it may contain large data such as SSH keys
```python
  _attributes = db.Column('attributes', db.String())
```

- Cleanup some code and comments

Unit Tests have been added and documentation updated for data initialization.

Thanks for your review.